### PR TITLE
Fix elliptic curve miscompilation on arm64 clang > 13

### DIFF
--- a/Formula/openssl@1.0.rb
+++ b/Formula/openssl@1.0.rb
@@ -19,6 +19,11 @@ class OpensslAT10 < Formula
     ENV.delete("PERL")
     ENV.delete("PERL5LIB")
 
+    # -O2 or greater with clang > 13 causes elliptic curve miscompilation on arm64
+    if OS.mac? and Hardware::CPU.arm? and MacOS.version >= :monterey
+      ENV.O1 if ENV.compiler == :clang
+    end
+
     ENV.deparallelize
     args = %W[
       --prefix=#{prefix}


### PR DESCRIPTION
Hey,

Just a super simple edit to prevent the Elliptic Curve module from mis-compiling on clang  >= 14 on arm64 machines. Turns out it was clang's over-aggressive optimizations. Wasn't sure if this issue affected any other machines, so I've limited the fix down to just arm64 Monterey and above.

Let me know if you have any feedback/suggestions and I'll be sure to implement them.

Cheers!